### PR TITLE
Fixed the truncation bug that long haunted us

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -148,7 +148,7 @@ cmd.prototype.run = function(stream, clients, serverAddress) {
     });
 
     prog.on("close", function() {
-        stream.end();
+        //stream.end();
     })    
 
     prog.stdin.on('error', function() {        
@@ -164,7 +164,7 @@ cmd.prototype.run = function(stream, clients, serverAddress) {
             var error = 'prog process exited with code ' + code         
             self.emit('error', error);         
         } else {
-            stream.end();
+            //stream.end();
         }
     }); 
 }


### PR DESCRIPTION
Culprit: output stream does not need to be closed manually
Since the program's stdout is piped to output stream, nodejs will
properly handle the closing of the stream when data in stdout pipe is
consumed. Capturing either the 'close', or the 'exit' event of the
running program, and close stream manually, will cause the stream to be
closed too early while data still sits in Linux pipe buffer, especially
under heavy load, and causes truncation to occur.